### PR TITLE
merge 0.4.8 into master

### DIFF
--- a/lib/yearn-core.js
+++ b/lib/yearn-core.js
@@ -34,8 +34,8 @@ core.populatePackageCache = function( package_json_location, parent ){
 		var contents = JSON5.parse( fs.readFileSync( package_json_location, 'utf8' ));
 		
 		core.package_dependencies[ package_json_location ] = merge( 
-			contents.dependencies,
 			contents.devDependencies,
+			contents.dependencies,
 			contents.optionalDependencies
 		);
 		

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yearn",
-	"version": "0.4.7",
+	"version": "0.4.8",
 	"description": "Override node's require mechanism.",
 	"keywords": [
 		"require",


### PR DESCRIPTION
Fixed bug where you couldn't use log4js because of conflicting dev and regular dependencies.  Dev dependencies are now overridden by regular dependencies.